### PR TITLE
On windows, require a double-click to show the window from the systray

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -66,9 +66,12 @@ bool AppGui::initialize()
         // On Linux/Windows, hide/show the app when the tray icon is clicked
         // On OSX this just shows the menu
 #ifndef Q_OS_MACX
-        if (reason == QSystemTrayIcon::DoubleClick ||
-            reason == QSystemTrayIcon::Trigger)
-        {
+        if (reason ==  QSystemTrayIcon::DoubleClick
+#ifndef Q_OS_WIN
+         //On linux, some Desktop environnements such as KDE won't let the user emit a double click
+         || reason == QSystemTrayIcon::Trigger
+#endif
+       ) {
             if (win->isHidden())
                 mainWindowShow();
             else


### PR DESCRIPTION

On windows, per #13,  the user now needs to double-click the systray icon to toggle the window visibility.
However, on Linux, a single click will still trigger a window visibility change. This is because various desktops environments such as KDE simply lack the double-click action 

