### PR TITLE
Allow changing the settings while no card is inserted.

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -48,6 +48,7 @@ private slots:
     void updatePage();
     void checkSettingsChanged();
     void memMgmtMode();
+    void enableKnockSettings(bool visible);
 
 //    void mpAdded(MPDevice *device);
 //    void mpRemoved(MPDevice *);

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -677,38 +677,61 @@ QWidget {background-color: #EFEFEF;}</string>
                 </widget>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_14">
-                 <item>
-                  <widget class="QCheckBox" name="checkBoxKnock">
-                   <property name="text">
-                    <string>Enable knock detection with</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboBoxKnock"/>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_30">
-                   <property name="text">
-                    <string>sensitivity</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_26">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
+                <widget class="QFrame" name="knockSettingsFrame">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <layout class="QHBoxLayout" name="knockSettingsLayout">
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxKnock">
+                    <property name="text">
+                     <string>Enable knock detection with</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="comboBoxKnock"/>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="knockSettingsSuffixLabel">
+                    <property name="text">
+                     <string>sensitivity</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_26">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
                </item>
                <item>
                 <widget class="QCheckBox" name="checkBoxFlash">


### PR DESCRIPTION
Allow changing the settings while no card is inserted
For security reason, the knock related settings are hidden and un-modifiable while a card is inserted