### PR TITLE
Only hide the application window when launched automatically.

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -21,6 +21,14 @@ bool AppGui::initialize()
     setAttribute(Qt::AA_UseHighDpiPixmaps);
 	setQuitOnLastWindowClosed(false);
 
+     QCommandLineParser parser;
+     QCommandLineOption autoLaunchedOption("autolaunched");
+     parser.addOption(autoLaunchedOption);
+     parser.process(*QCoreApplication::instance());
+
+     bool autoLaunched = parser.isSet(autoLaunchedOption);
+
+
     if (!createSingleApplication())
         return false;
 
@@ -92,8 +100,8 @@ bool AppGui::initialize()
     {
         mainWindowHide();
     });
-    //start hidden
-    mainWindowHide();
+
+    autoLaunched ?  mainWindowHide() : mainWindowShow();
 
     connect(wsClient, &WSClient::showAppRequested, [=]()
     {

--- a/src/AutoStartup.cpp
+++ b/src/AutoStartup.cpp
@@ -14,7 +14,7 @@ void AutoStartup::enableAutoStartup(bool en)
         //Install registry key
         QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
                            QSettings::NativeFormat);
-        settings.setValue("Moolticute", QDir::toNativeSeparators(qApp->applicationFilePath()));
+        settings.setValue("Moolticute", QStringLiteral("\%1\" --autolaunched").arg(QDir::toNativeSeparators(qApp->applicationFilePath()));
         settings.sync();
     }
     else
@@ -30,7 +30,7 @@ void AutoStartup::enableAutoStartup(bool en)
                                           "Comment=Mooltipass companion\n"
                                           "Icon=moolticute\n"
                                           "Type=Application\n"
-                                          "Exec=%1\n"
+                                          "Exec=\"%1\" --autolaunched %U\n"
                                           "Hidden=false\n"
                                           "NoDisplay=false\n"
                                           "X-GNOME-Autostart-enabled=true\n")


### PR DESCRIPTION
 * Fix path escaping when registering an autostart item.
 * When launched by the user, show the main window
 * when launched by the system, hide the application in the systray.

The command line parameter --autolaunched controls this behaviour.