### PR TITLE
Implemented:

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -59,6 +59,7 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
 
     credFilterModel->setSourceModel(credModel);
     ui->credentialsListView->setModel(credFilterModel);
+    connect(credModel, &CredentialsModel::modelLoaded, ui->credentialsListView, &CredentialsView::onModelLoaded);
 
     QDataWidgetMapper* mapper = new QDataWidgetMapper(this);
     mapper->setItemDelegate(new CredentialViewItemDelegate(mapper));
@@ -286,9 +287,9 @@ bool CredentialsManagement::confirmDiscardUneditedCredentialChanges(QModelIndex 
     QString description = ui->credDisplayDescriptionInput->text();
     QString login = ui->credDisplayLoginInput->text();
 
-    if (password != cred.password ||
-        description != cred.description ||
-        login != cred.login)
+    if ((!password.isEmpty() && (password != cred.password)) ||
+        (!description.isEmpty() && (description != cred.description)) ||
+        (!login.isEmpty() && (login != cred.login)))
     {
         auto btn = QMessageBox::question(this,
                                          tr("Discard Modifications ?"),

--- a/src/CredentialsModel.cpp
+++ b/src/CredentialsModel.cpp
@@ -109,7 +109,7 @@ void CredentialsModel::load(const QJsonArray &json)
         }
     }
     mergeWith(creds);
-
+    emit modelLoaded();
 }
 
 
@@ -304,3 +304,4 @@ void CredentialsModel::removeCredential(const QModelIndex &idx)
     m_credentials.remove(idx.row());
     endRemoveRows();
 }
+

--- a/src/CredentialsModel.h
+++ b/src/CredentialsModel.h
@@ -115,6 +115,9 @@ private:
     friend class CredentialsFilterModel;
     friend class CredentialsManagement;
     friend class ServiceItemDelegate;
+
+signals:
+    void modelLoaded();
 };
 
 #endif // CREDENTIALSMODEL_H

--- a/src/CredentialsView.cpp
+++ b/src/CredentialsView.cpp
@@ -46,6 +46,15 @@ CredentialsView::CredentialsView(QWidget *parent)
     setItemDelegateForColumn(0, new ServiceItemDelegate(this));
 }
 
+void CredentialsView::onModelLoaded()
+{
+    QModelIndex firstIndex = model()->index(0, 0, QModelIndex());
+    if (firstIndex.isValid()) {
+        ConditionalItemSelectionModel *pSelectionModel = dynamic_cast<ConditionalItemSelectionModel *>(selectionModel());
+        pSelectionModel->setCurrentIndex(firstIndex, QItemSelectionModel::ClearAndSelect);
+    }
+}
+
 ConditionalItemSelectionModel::ConditionalItemSelectionModel(TestFunction f, QAbstractItemModel *model)
  : QItemSelectionModel(model)
  , cb(f)

--- a/src/CredentialsView.h
+++ b/src/CredentialsView.h
@@ -26,8 +26,13 @@
 
 class CredentialsView : public QListView
 {
+    Q_OBJECT
+
 public:
     explicit CredentialsView(QWidget *parent = nullptr);
+
+public slots:
+    void onModelLoaded();
 };
 
 class ConditionalItemSelectionModel : public QItemSelectionModel {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -27,6 +27,7 @@
 namespace Ui {
 class MainWindow;
 }
+class QShortcut;
 
 class MainWindow : public QMainWindow
 {
@@ -80,6 +81,8 @@ private slots:
     void on_pushButtonSettingsReset_clicked();
     void on_pushButtonSettingsSave_clicked();
 
+    void onKeyboardShortcutActivated();
+
 private:
     void setUIDRequestInstructionsWithId(const QString &id = "XXXX");
 
@@ -96,6 +99,9 @@ private:
     QByteArray logBuffer;
 
     QMovie* gb_spinner;
+
+    QShortcut *keyboardShortcut;
+    bool bFilesAndSSHKeyTabsVisible;
 };
 
 #endif // MAINWINDOW_H

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -128,6 +128,9 @@ QWidget {background-color: #EFEFEF;}</string>
          <property name="text">
           <string>Files</string>
          </property>
+         <property name="shortcut">
+          <string>Ctrl+A, Ctrl+D, Ctrl+F</string>
+         </property>
          <property name="checkable">
           <bool>true</bool>
          </property>
@@ -140,6 +143,9 @@ QWidget {background-color: #EFEFEF;}</string>
         <widget class="QPushButton" name="pushButtonSSH">
          <property name="text">
           <string>SSH Keys</string>
+         </property>
+         <property name="shortcut">
+          <string>Ctrl+A, Ctrl+D, Ctrl+F</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -2197,8 +2203,6 @@ QWidget {background-color: #EFEFEF;}</string>
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../img/images.qrc"/>
-  <include location="../img/images.qrc"/>
   <include location="../img/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
1/ choisir par défaut le premier credential plutot que de laisser désactiver la partie de droite. Dans le cas d'une base de donnée vide, laisser tout désactivé à droite

2/ ajouter un racourci clavier (du type ctrl-a-d-f) pour afficher les tabs "Files" et "SSH Keys" (remarque: le shortcut est CTRL+SHIFT+F1)